### PR TITLE
docs: add ship skill for end-to-end git workflow

### DIFF
--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: ship
+description: >
+  End-to-end git workflow: commit changes, push to branch, and open a PR.
+  Handles both staged and unstaged changes. When files are staged, commits them directly.
+  When nothing is staged, discovers all changed files, groups them logically, and creates
+  progressive commits before pushing and opening a PR.
+  Triggers on: "/ship", "ship these changes", "commit push and PR",
+  "commit the staged stuff and open a PR", "push and PR",
+  "create commits from staged changes and raise a PR", "ship it".
+  Do NOT trigger for plain commit-only requests (/commit) or general git questions.
+---
+
+## Overview
+
+Ship all pending work: commit, push, and open a crisp PR. Works in two modes:
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| **Staged** | Files are staged (`git diff --staged` is non-empty) | Single commit of staged files |
+| **Auto-group** | Nothing staged, but unstaged/untracked changes exist | Discover → group → progressive commits |
+
+## Workflow
+
+### 1. Detect mode & prepare
+
+```bash
+git diff --staged --name-status
+```
+
+- **Non-empty** → **Staged mode**: follow [references/staged-workflow.md](references/staged-workflow.md)
+- **Empty** → check for unstaged/untracked changes:
+  ```bash
+  git status --porcelain
+  ```
+  - **Non-empty** → **Auto-group mode**: follow [references/unstaged-workflow.md](references/unstaged-workflow.md)
+  - **Empty** → nothing to ship. Stop and tell the user.
+
+### 2. Resolve branch
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+- **On `main` (or `master`)**: create a new feature branch:
+  ```bash
+  git checkout -b u/tezansahu/<camelCaseDescriptor>
+  ```
+  Derive `<camelCaseDescriptor>` from the changes (e.g., `addShipSkill`, `fixLatencyMetrics`, `authAndDocs`). Always camelCase, always `u/tezansahu/` prefix.
+- **On a feature branch**: stay on it.
+
+### 3. Commit
+
+Use Conventional Commits prefixes (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `perf:`). Focus on **why**, not just what.
+
+```bash
+git commit -m "$(cat <<'EOF'
+<type>: <concise 1-line summary>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Use the exact model name matching the current session (default: `Claude Sonnet 4.6`).
+
+- **Staged mode**: single commit of all validated staged files.
+- **Auto-group mode**: progressive commits — stage and commit one group at a time per the approved plan. Verify each with `git log -1 --oneline` before moving to the next.
+
+**Hard rules:**
+- Never `--amend` — always create a new commit
+- Never `--no-verify` — if a hook fails: diagnose, explain to user, propose fix, wait for confirmation, then create a new commit
+- Verify after commit: `git log -1 --oneline`
+
+### 4. Push
+
+```bash
+# Check if upstream is set:
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
+
+# No upstream (new branch):
+git push -u origin <branch>
+
+# Upstream already set:
+git push
+```
+
+Never force-push.
+
+### 5. Open PR
+
+Analyze all commits on the branch:
+
+```bash
+git log main..<branch> --oneline
+```
+
+```bash
+gh pr create --title "<concise title under 70 chars>" --body "$(cat <<'EOF'
+## Summary
+- <bullet 1>
+- <bullet 2 if needed>
+
+## Test plan
+- [ ] <what to verify>
+
+---
+Co-authored with [GitHub Copilot](https://github.com/features/copilot)
+EOF
+)"
+```
+
+**PR rules:**
+- Title: short, factual, under 70 chars
+- Summary: 1–3 bullets — what changed and why. For multi-commit PRs, summarize the overall change
+- Test plan: concrete checkboxes, not boilerplate
+- Footer: `Co-authored with [GitHub Copilot](https://github.com/features/copilot)` when running as Copilot; `Co-authored with [Claude Code](https://claude.com/claude-code)` for Claude Code sessions
+
+Return the PR URL to the user.
+
+## Secret files
+
+In both modes, warn and exclude these from staging/committing:
+- `.env`, `.env.*`
+- `credentials.json`, `**/credentials.json`
+- `*.pem`, `*.key`, `*.p12`, `*.pfx`
+- Any file matching common secret patterns

--- a/skills/ship/references/staged-workflow.md
+++ b/skills/ship/references/staged-workflow.md
@@ -1,0 +1,24 @@
+# Staged Workflow — Preparation
+
+Run when `git diff --staged --name-status` is non-empty.
+After these steps, return to [SKILL.md](../SKILL.md) step 2 (Resolve branch).
+
+## 1. Review staged files
+
+```bash
+git diff --staged --name-status
+git diff --staged
+```
+
+- Never use `git status -uall`, `git diff HEAD`, or include unstaged files.
+- Only operate on what is staged — do not touch the working tree.
+
+## 2. Security check
+
+Scan the staged file list for secret files (see patterns in [SKILL.md](../SKILL.md#secret-files)). **Unstage** any matches:
+
+```bash
+git reset HEAD <secret-file>
+```
+
+Inform the user which files were excluded and why.

--- a/skills/ship/references/unstaged-workflow.md
+++ b/skills/ship/references/unstaged-workflow.md
@@ -1,0 +1,73 @@
+# Unstaged Workflow — Preparation
+
+Run when nothing is staged but `git status --porcelain` shows changed/untracked files.
+After these steps, return to [SKILL.md](../SKILL.md) step 2 (Resolve branch).
+
+## 1. Discover all changed files
+
+```bash
+git status --porcelain
+```
+
+This returns lines like:
+- ` M path/file` — modified, not staged
+- `?? path/file` — untracked
+- ` D path/file` — deleted, not staged
+- `MM path/file` — modified, partially staged (treat unstaged part)
+
+Collect all file paths and their statuses.
+
+## 2. Security check
+
+Scan for secret files (see patterns in [SKILL.md](../SKILL.md#secret-files)). **Exclude** any matches from the grouping plan. Warn the user which files are excluded. Do not stage or commit them.
+
+## 3. Read diffs for context
+
+```bash
+git diff                         # modified tracked files
+git diff --no-index /dev/null <file>   # untracked files (to see content)
+```
+
+Read enough of each file/diff to understand its purpose. For large files, read the first ~100 lines.
+
+## 4. Group files into logical commits
+
+Analyze the files and group them by **logical cohesion**. Use these heuristics (in priority order):
+
+1. **Same feature/module**: files in the same directory or module that serve the same feature
+2. **Same concern**: e.g., all config changes together, all test files together, all docs together
+3. **Cross-cutting but related**: e.g., a utility + the files that use it
+4. **Independent standalone changes**: e.g., a lone README fix, a single typo
+
+**Grouping rules:**
+- Each group should be a self-contained, reviewable unit
+- A group should have 1–8 files; split larger groups further
+- Prefer fewer groups over many tiny single-file commits (unless they are truly independent)
+- Untracked files go with the group they logically belong to (e.g., a new test file with the feature it tests)
+- Deleted files go with the group that explains the deletion (e.g., a refactor that removes old code)
+
+## 5. Present the plan to the user
+
+Before committing, show the user the proposed grouping:
+
+```
+Proposed commits (in order):
+
+1. feat: add user auth middleware
+   - src/middleware/auth.ts
+   - src/middleware/auth.test.ts
+   - src/types/auth.ts
+
+2. docs: update API reference for auth endpoints
+   - docs/api/auth.md
+   - README.md
+
+3. chore: update dependencies
+   - package.json
+   - package-lock.json
+```
+
+Ask for confirmation. The user may:
+- **Approve** → proceed
+- **Rearrange** → adjust groups and re-present
+- **Exclude files** → remove files from the plan


### PR DESCRIPTION
## Summary

- Add ship skill that automates commit, push, and PR creation workflows
- Supports two modes: staged (single commit) and auto-group (progressive commits)
- Includes reference docs for staged and unstaged workflow details

## Test plan

-  Verify `SKILL.md` renders correctly on GitHub
-  Confirm staged and unstaged workflow references link properly

_Co-authored with GitHub Copilot_